### PR TITLE
fixed creation of GuidTag

### DIFF
--- a/src/cloudscribe.Syndication/Models/Rss/DefaultXmlFormatter.cs
+++ b/src/cloudscribe.Syndication/Models/Rss/DefaultXmlFormatter.cs
@@ -133,7 +133,7 @@ namespace cloudscribe.Syndication.Models.Rss
                             new XElement(Rss20Constants.TitleTag, item.Title),
                             new XElement(Rss20Constants.DescriptionTag, new XCData(item.Description)),
                             new XElement(Rss20Constants.LinkTag, item.Link.ToString()),
-                            new XElement(Rss20Constants.GuidTag, item.Link.ToString()),
+                            new XElement(Rss20Constants.GuidTag, item.Guid.Value),
                             new XElement(Rss20Constants.PubDateTag, item.PublicationDate.ToString("R"))
                            );
 


### PR DESCRIPTION
I have just noticed that both tags link and guid of an rss item had the same information in it so I created this small fix to solve this issue.